### PR TITLE
Fix: #15 Corrigindo respostas únicas

### DIFF
--- a/app/Http/Livewire/Reply/Create.php
+++ b/app/Http/Livewire/Reply/Create.php
@@ -22,10 +22,11 @@ class Create extends \App\Http\Livewire\Crud\Main
     protected function assetUserCanReply()
     {
         $user = auth()->user();
-
         if (!$this->form->canBeRepliedBy($user)) {
-            throw ValidationException::withMessages(['generic_error' => 'your error message']);
+            // throw ValidationException::withMessages(['generic_error' => 'your error message']);
+            return false;
         }
+        return true;  
     }
 
     /**
@@ -37,7 +38,7 @@ class Create extends \App\Http\Livewire\Crud\Main
      */
     protected function prepareModelCrudInfo(array $modelCrudInfo) :array
     {
-        $this->assetUserCanReply();
+        
 
         if (empty($this->form->questions)) {
             // Não há campos extras para uma solicitação desse tipo de serviço,
@@ -59,16 +60,14 @@ class Create extends \App\Http\Livewire\Crud\Main
             // Vamos colocar como label do campo o próprio texto usado para
             // criar essa pergunta.
 
-          
-
-
             $modelCrudInfo['fields'][$key] = $poll[$index];
             $modelCrudInfo['fields'][$key]['label'] = $field['text'] ?? '';
             $modelCrudInfo['fields'][$key]['validation'] = 'present';
         
         }
-
+        
         return $modelCrudInfo;
+       
     }
 
     /**

--- a/resources/views/livewire/crud/change.blade.php
+++ b/resources/views/livewire/crud/change.blade.php
@@ -141,7 +141,7 @@
                     <button wire:click="cancel()" class="btn float-right mr-6">Cancelar</button>
                 @endif
             @else
-                <button wire:click="store()" class="btn btn-wide btn-primary ml-auto mr-auto d-flex">Enviar</button>
+                <button wire:click="store({{$form->id}})" class="btn btn-wide btn-primary ml-auto mr-auto d-flex">Enviar</button>
             @endif
         @endif
     @endif

--- a/resources/views/livewire/crud/success.blade.php
+++ b/resources/views/livewire/crud/success.blade.php
@@ -8,7 +8,7 @@
         </div>
 
         <div class="flex-none">
-            <button class="btn btn-sm btn-success pt-0" wire:click="finished(false)">Ok</button>
+            <button class="btn btn-sm btn-success pt-0" wire:click="finished(false, {{$form->id}})">Ok</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
As funções 'store' e 'finished' foram alteradas para receber o id do formulário.
Obtendo também o respectivo usuário com 'Auth->user' podemos verificar na função 'canBeRepliedBy' do próprio form se o usuário pode ainda estar respondendo aquele formulário, com isso ficou bloqueado para em formulários de resposta única, a possibilidade de ter duas respostas de um mesmo usuário.

No caso de um formulário de resposta única, o usuário ao responder recebe a mensagem de resposta enviada e ao clicar em 'ok' é exibido a outra tela explicando que não será possível estar respondendo novamente aquele formulário.

Caso o formulário não exija respostas únicas, o formulário é exibido novamente após clicar em 'ok'.

