### PR TITLE
Criando opção de configurar tipos de respostas

### DIFF
--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -25,6 +25,7 @@ class FormController extends Controller
         $form = Form::create([
             'title' => '',
             'user_questions' => '',
+            'config_questions' => '',
             'questions' => [],
             'user_id' => Auth::user()->id,
             'hash' => Str::random(32),

--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -25,7 +25,6 @@ class FormController extends Controller
         $form = Form::create([
             'title' => '',
             'user_questions' => '',
-            'config_questions' => '',
             'questions' => [],
             'user_id' => Auth::user()->id,
             'hash' => Str::random(32),

--- a/app/Http/Livewire/Form/Edit.php
+++ b/app/Http/Livewire/Form/Edit.php
@@ -94,7 +94,7 @@ class Edit extends Component
         }
 
         if($field == "question_config"){
-          
+            
             $update_config = explode(',', $value);
             $this->form->questions[$update_config[0]]['question_config'] = $update_config[1];
 

--- a/app/Http/Livewire/Form/Edit.php
+++ b/app/Http/Livewire/Form/Edit.php
@@ -6,7 +6,6 @@ use App\Model\Form;
 use CCUFFS\Text\PollFromText;
 use Livewire\Component;
 use App\Events\FormUpdated;
-use Illuminate\Support\Facades\Input;
 
 class Edit extends Component
 {
@@ -19,16 +18,13 @@ class Edit extends Component
         'form.user_questions' => 'present',
         'form.is_accepting_replies' => 'present',
         'form.is_auth_required' => 'present',
-        'form.is_one_reply_only' => 'present',
+        'form.is_one_reply_only' => 'present'
     ];
 
 
     public function mount(Form $form)
     {
         $this->form = $form;
-      
-        // $this->renderConfigReplies($this->form->user_questions);
-        
         $this->renderUserQuestion($this->form->user_questions);
     }
 
@@ -85,7 +81,6 @@ class Edit extends Component
                     }
                 }
             }
-            
             $this->form->save();            
         }
 
@@ -94,17 +89,10 @@ class Edit extends Component
         }
 
         if($field == "question_config"){
-            
             $update_config = explode(',', $value);
             $this->form->questions[$update_config[0]]['question_config'] = $update_config[1];
-
-            // $this->question_config[$update_config[0]] = $update_config[1];
             $this->form->save();
-
-            // var_dump($this->form->questions);
         }
-
-       
 
         $this->update();
     }

--- a/app/Model/Form.php
+++ b/app/Model/Form.php
@@ -32,6 +32,7 @@ class Form extends Model
         'title',
         'user_questions',
         'questions',
+        'config_questions',
         'hash',
         'status',
     ];
@@ -81,6 +82,16 @@ class Form extends Model
             'user_questions' => [
                 'label' => 'Perguntas',
                 'type' => 'poll',
+                'show' => 'create,edit',
+            ],  
+            'questions[]' => [
+                'label' => 'Configurações',
+                'type' => 'text',
+                'show' => 'create,edit',
+            ],  
+            'config_questions' => [
+                'label' => 'Configurações',
+                'type' => 'poll_config',
                 'show' => 'create,edit',
             ],            
         ]

--- a/app/Model/Form.php
+++ b/app/Model/Form.php
@@ -32,9 +32,26 @@ class Form extends Model
         'title',
         'user_questions',
         'questions',
-        'config_questions',
         'hash',
         'status',
+    ];
+
+
+    public $answer_types = [
+        'input' => [
+            0 => 'text',
+            1 => 'date',
+            2 => 'time',
+            3 => 'tel',
+            4 => 'email',
+            5 => 'file'
+        ],
+        'select' => [
+           0 => 'select',
+           1 => 'radio',
+           2 => 'checkbox',
+           3 => 'custom'
+        ]
     ];
 
 
@@ -88,12 +105,7 @@ class Form extends Model
                 'label' => 'Configurações',
                 'type' => 'text',
                 'show' => 'create,edit',
-            ],  
-            'config_questions' => [
-                'label' => 'Configurações',
-                'type' => 'poll_config',
-                'show' => 'create,edit',
-            ],            
+            ]           
         ]
     ];
 

--- a/app/Model/Form.php
+++ b/app/Model/Form.php
@@ -100,12 +100,7 @@ class Form extends Model
                 'label' => 'Perguntas',
                 'type' => 'poll',
                 'show' => 'create,edit',
-            ],  
-            'questions[]' => [
-                'label' => 'Configurações',
-                'type' => 'text',
-                'show' => 'create,edit',
-            ]           
+            ]        
         ]
     ];
 

--- a/resources/views/livewire/form/edit.blade.php
+++ b/resources/views/livewire/form/edit.blade.php
@@ -2,7 +2,7 @@
     <div x-data="{ tab: window.location.hash ? window.location.hash.substring(1) : 'questions' }" id="tab_wrapper">
         <div class="tabs row">
             <a :class="{ 'tab-active': tab === 'questions' }" @click.prevent="tab = 'questions'; window.location.hash = 'questions'" href="#" class="tab tab-lifted col-md-2 col-sm-4">Perguntas</a>
-            <a :class="{ 'tab-active': tab === 'config_questions' }" @click.prevent="tab = 'config_questions'; window.location.hash = 'config_questions'" href="#" class="tab tab-lifted col-md-2 col-sm-4">Configurar Perguntas</a>
+            <a :class="{ 'tab-active': tab === 'config_questions' }" @click.prevent="tab = 'config_questions'; window.location.hash = 'config_questions'" href="#" class="tab tab-lifted col-md-2 col-sm-4">Configurar Respostas</a>
             <a :class="{ 'tab-active': tab === 'permissions' }" @click.prevent="tab = 'permissions'; window.location.hash = 'permissions'" href="#" class="tab tab-lifted col-md-2 col-sm-4">Permissões</a>
             <a :class="{ 'tab-active': tab === 'replies' }" @click.prevent="tab = 'replies'; window.location.hash = 'replies'" href="#" class="tab tab-lifted col-md-2 col-sm-4">Respostas <span id="repliesBadge"></span></a>
             <!-- <a href="#" class="tab tab-lg tab-lifted text-white col-6">|</a> -->
@@ -49,47 +49,30 @@
                 <div class="col-12 pt-2">
                     <div class="w-full">
                         <div class="col-12">
-                            <label for="config_questions" class="label">
+                            <label class="label">
                                 <span class="label-text">Selecione o tipo de resposta para cada pergunta:</span>
                             </label>
                         </div>
-                        @foreach ($form->questions as $index => $question)
-                            <div class="col-12">
-                                <label for="config_questions" class="label">
-                                    <span class="label-text">{{$question['text']}}</span>
-                                </label>
+                        @foreach ($form->questions as $question_id => $question)
+                            <div class="col-md-4">
+                                <div class="form-control border-radius-5">
+                                    <label>
+                                        <span class="label-text">Pergunta: <strong>{{$question['text']}}</strong></span>
+                                    </label>   
+                                    <label>
+                                        <span class="label-text">Aceitando respostas do tipo: <strong>{{$form->answer_types[$question['type']][$question['question_config']]}}</strong></span>
+                                    </label>
+                                    <label class="d-block">
+                                        <span class="label-text">Mudar para:</span>
+                                        <select wire:model="question_config">
+                                            @foreach ($form->answer_types[$question['type']] as $index_type => $type)
+                                                <option value="{{$question_id}},{{$index_type}}">{{$type}}</option>
+                                            @endforeach
+                                        </select>
+                                    </label>
+                                </div>
                             </div>
-                            {{$question['question_config']}}
-                            {{$question['type']}}
-
-                            @if($question['type'] == 'input')
-                                <select wire:model="question_config" class="float-left">
-                                    <option value="{{$index}},0">Padrao</option>
-                                    <option value="{{$index}},1">Data</option>
-                                    <option value="{{$index}},2">Hora</option>
-                                    <option value="{{$index}},3">Telefone</option>
-                                    <option value="{{$index}},4">E-mail</option>
-                                    <option value="{{$index}},5">Arquivo</option>
-                                </select>
-
-                                <!-- <input type="radio" name="config_{{$index}}" wire:model="question_config" value="{{$index}},0"> Padrao
-                                <input type="radio" name="config_{{$index}}" wire:model="question_config" value="{{$index}},1"> Data
-                                <input type="radio" name="config_{{$index}}" wire:model="question_config" value="{{$index}},2"> Hora
-                                <input type="radio" name="config_{{$index}}" wire:model="question_config" value="{{$index}},3"> Telefone
-                                <input type="radio" name="config_{{$index}}" wire:model="question_config" value="{{$index}},4"> E-mail
-                                <input type="radio" name="config_{{$index}}" wire:model="question_config" value="{{$index}},5"> Arquivo -->
-
-
-                            @elseif($question['type'] == 'select')
-                                <select wire:model="question_config" class="float-left">
-                                    <option value="{{$index}},0">Select (Resposta Única)</option>
-                                    <option value="{{$index}},1">Radio (Resposta Única)</option>
-                                    <option value="{{$index}},2">Checkbox (Multiplas Respostas)</option>
-                                    <option value="{{$index}},3">Escala Horizontal</option>
-                                </select>
-                            @endif
                             <br><br>
-
                         @endforeach
                     </div>
                 </div>

--- a/resources/views/livewire/form/edit.blade.php
+++ b/resources/views/livewire/form/edit.blade.php
@@ -1,10 +1,8 @@
 <div>
- 
-    
     <div x-data="{ tab: window.location.hash ? window.location.hash.substring(1) : 'questions' }" id="tab_wrapper">
-
         <div class="tabs row">
             <a :class="{ 'tab-active': tab === 'questions' }" @click.prevent="tab = 'questions'; window.location.hash = 'questions'" href="#" class="tab tab-lifted col-md-2 col-sm-4">Perguntas</a>
+            <a :class="{ 'tab-active': tab === 'config_questions' }" @click.prevent="tab = 'config_questions'; window.location.hash = 'config_questions'" href="#" class="tab tab-lifted col-md-2 col-sm-4">Configurar Perguntas</a>
             <a :class="{ 'tab-active': tab === 'permissions' }" @click.prevent="tab = 'permissions'; window.location.hash = 'permissions'" href="#" class="tab tab-lifted col-md-2 col-sm-4">Permissões</a>
             <a :class="{ 'tab-active': tab === 'replies' }" @click.prevent="tab = 'replies'; window.location.hash = 'replies'" href="#" class="tab tab-lifted col-md-2 col-sm-4">Respostas <span id="repliesBadge"></span></a>
             <!-- <a href="#" class="tab tab-lg tab-lifted text-white col-6">|</a> -->
@@ -44,7 +42,58 @@
             <div class="w-100 mt-10">
                 <a href="{{ route('form.delete', [$form->id ,$form->hash]) }}" onclick="if (confirm('Tem certeza que deseja descartar este formulário?')){return true;}else{event.stopPropagation(); event.preventDefault();};"  class="btn btn-danger-custom">Cancelar formulário</a>   
             </div>
+        </div>
 
+        <div x-show="tab === 'config_questions'" class="row pb-4 pt-4">       
+            <div class="row">
+                <div class="col-12 pt-2">
+                    <div class="w-full">
+                        <div class="col-12">
+                            <label for="config_questions" class="label">
+                                <span class="label-text">Selecione o tipo de resposta para cada pergunta:</span>
+                            </label>
+                        </div>
+                        @foreach ($form->questions as $index => $question)
+                            <div class="col-12">
+                                <label for="config_questions" class="label">
+                                    <span class="label-text">{{$question['text']}}</span>
+                                </label>
+                            </div>
+                            {{$question['question_config']}}
+                            {{$question['type']}}
+
+                            @if($question['type'] == 'input')
+                                <select wire:model="question_config" class="float-left">
+                                    <option value="{{$index}},0">Padrao</option>
+                                    <option value="{{$index}},1">Data</option>
+                                    <option value="{{$index}},2">Hora</option>
+                                    <option value="{{$index}},3">Telefone</option>
+                                    <option value="{{$index}},4">E-mail</option>
+                                    <option value="{{$index}},5">Arquivo</option>
+                                </select>
+
+                                <!-- <input type="radio" name="config_{{$index}}" wire:model="question_config" value="{{$index}},0"> Padrao
+                                <input type="radio" name="config_{{$index}}" wire:model="question_config" value="{{$index}},1"> Data
+                                <input type="radio" name="config_{{$index}}" wire:model="question_config" value="{{$index}},2"> Hora
+                                <input type="radio" name="config_{{$index}}" wire:model="question_config" value="{{$index}},3"> Telefone
+                                <input type="radio" name="config_{{$index}}" wire:model="question_config" value="{{$index}},4"> E-mail
+                                <input type="radio" name="config_{{$index}}" wire:model="question_config" value="{{$index}},5"> Arquivo -->
+
+
+                            @elseif($question['type'] == 'select')
+                                <select wire:model="question_config" class="float-left">
+                                    <option value="{{$index}},0">Select (Resposta Única)</option>
+                                    <option value="{{$index}},1">Radio (Resposta Única)</option>
+                                    <option value="{{$index}},2">Checkbox (Multiplas Respostas)</option>
+                                    <option value="{{$index}},3">Escala Horizontal</option>
+                                </select>
+                            @endif
+                            <br><br>
+
+                        @endforeach
+                    </div>
+                </div>
+            </div>
         </div>
 
         <textarea wire:model="poll_view" name="poll_view" x-ref="poll_view" class="hidden"></textarea>


### PR DESCRIPTION
Exemplo de como ficou:

A partir das perguntas abaixo:
![image](https://user-images.githubusercontent.com/74692811/177538907-b5115712-5651-40f3-a46a-c536545b897f.png)

Nessa nova tab, é configurável o tipo de resposta que estamos aceitando:
![image](https://user-images.githubusercontent.com/74692811/177539348-eb869ca7-e7f4-4613-abf9-b5505ec18a83.png)


Deixei visualmente nesse formato, precisaria corrigir o option 'selected' do select de cada configuração, mas isso seria um ajuste futuro, quando eu descobrir como o laravel trata arrays flexíveis de inputs que volto para fazer esse tratamento.

Agora já podemos configurar a tela de respondente para suportar receber esses tipos de resposta.
