### PR TITLE
Fix:#28 Relatório de arquivos submetidos, opção de baixar zip ou arquivo individual

### DIFF
--- a/resources/js/practice-form.js
+++ b/resources/js/practice-form.js
@@ -1,5 +1,5 @@
 const {
-    isSet, defaultsDeep
+    isSet, defaultsDeep, split
 } = require("lodash");
 
 var PracticeForms = {
@@ -71,12 +71,21 @@ var PracticeForms = {
 
         var chartExists = $('#' + this.config.repliesContainerId + ' .no-replies-yet');
 
-        rows.push('<div class="mb-4 w-full">');
-        rows.push('<div class="font-bold text-center mb-4 mt-10">' + question + (result.questions[question] == undefined ? ' <p class="badge badge-pill badge-error p-2 pt-1 pb-1 border border-warning">Desativada</p>' : '') + '</div>');
+        var checkfilename = result.replies[question][0].split('/');
 
-        //percorre todas as respostas
+        rows.push('<div class="mb-4 w-full">');
+        rows.push('<div class="font-bold text-center mb-4 mt-10">' + question + (checkfilename[0] == 'crud_uploads' ? '<a class="m-1" href="/download/zip/'+this.config.formId+'/'+question+'">(Baixar arquivos)</a>' : '') + (result.questions[question] == undefined ? ' <p class="badge badge-pill badge-error p-2 pt-1 pb-1 m-1 border border-warning">Desativada</p>' : '') + '</div>');
+
+        //percorre todas as respostas  
         for (reply in result.replies[question]) {
-            rows.push('<div class="border h-10 p-2 chart-text-entry">' + result.replies[question][reply] + '</div>');
+            checkfilename = result.replies[question][reply].split('/');
+            //detecta resposta do tipo file
+            if(checkfilename[0] == 'crud_uploads'){
+                rows.push('<div class="border h-10 p-2 chart-text-entry"><a href="/download/'+checkfilename[1]+'">' + result.replies[question][reply] + '</href></div>');
+            }else{
+                rows.push('<div class="border h-10 p-2 chart-text-entry">' + result.replies[question][reply] + '</div>');
+            }
+            
         }
         rows.push('</div>');
 
@@ -220,6 +229,7 @@ var PracticeForms = {
         //percorre todas as perguntas
         for (question in result.replies) {
 
+          
             $type = result.replies[question]['type'];
             delete result.replies[question]['type'];
            

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,6 +55,8 @@ Route::group(['middleware' => 'auth'], function () {
     Route::get('/resultado/{form}/{hash}', [FormController::class, 'result'])->name('form.result');
     Route::get('/remover/{form}/{hash}', [FormController::class, 'delete'])->name('form.delete');
     Route::get('/report/{form}', [FormController::class, 'report'])->name('form.report');
+    Route::get('/download/{filename}', [FormController::class, 'getDownload'])->name('question.download');
+    Route::get('/download/zip/{form}/{question}',  [FormController::class, 'getDownloadZip'])->name('question.downloadZip');
 
     // Admin
     Route::group(['middleware' => 'check.admin'], function () {


### PR DESCRIPTION
A opção ficou disponível na tela de relatórios e aparece inclusive quando a pergunta está desativada (precisou um tratamento diferente pra isso pois a pergunta não listava)

Clicando no nome do arquivo ou em 'baixar respostas' no lado do texto da pergunta, ele faz o download dos arquivos.

O upload de arquivos está aceitando qualquer tipo de arquivo, uma ideia pro futuro é tratar o tipo de arquivo permitido, como por exemplo aceitar somente pdfs ou fotos.

![image](https://user-images.githubusercontent.com/74692811/179600886-1bc85ab2-c3fc-47c2-91ee-c09e9ac28617.png)
