### PR TITLE
#25 - Barra de carregamento na tela de respondente

### DIFF
--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -2144,3 +2144,16 @@ section.hero-slim {
 .custom-container{
   margin-top: 150px;
 }
+
+/* progress bar */
+#myProgress {
+  width: 100%;
+  background-color: grey;
+}
+
+#myBar {
+  width: 1%;
+  height: 30px;
+  background-color: green;
+}
+

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -11,3 +11,4 @@ import ApexCharts from 'apexcharts'
 window.ApexCharts = ApexCharts;
 
 require('./practice-form');
+require('./progress-bar');

--- a/resources/js/progress-bar.js
+++ b/resources/js/progress-bar.js
@@ -1,0 +1,113 @@
+var ProgressBar = {
+    config: {
+        countFields : 0,
+        answeredFields : [],
+        totalAnsweredFields : 0,
+    
+        containerId : '',
+        containerWidth : 1, //percent
+    },
+ 
+    init: function (config) {
+        this.config = config;
+        return this;
+    },
+
+    updateWidth(direction) {
+        var i = 0;
+        if (i == 0) {
+            i = 1;
+            var elementContainer = document.getElementById(ProgressBar.config.containerId);
+            var id = setInterval(frame, 25);
+            
+            function frame() {
+                //stop condition
+                if (direction == 'up' && ProgressBar.config.containerWidth >= Math.round((ProgressBar.config.totalAnsweredFields/ProgressBar.config.countFields*100)) || direction == 'down' && ProgressBar.config.containerWidth <= Math.round((ProgressBar.config.totalAnsweredFields/ProgressBar.config.countFields*100))) {
+                    clearInterval(id);
+                    i = 0;
+                    elementContainer.style.width = ProgressBar.config.containerWidth + "%";
+                } else {
+                    switch(direction){
+                        case 'up':
+                            ProgressBar.config.containerWidth++;
+                            break;
+                        case 'down':
+                            ProgressBar.config.containerWidth--;
+                            break;
+                        default:
+                            break;
+                    }
+
+                    elementContainer.style.width = ProgressBar.config.containerWidth + "%";
+                }
+            }
+        }
+    },
+
+    //onChange event in form input
+    fieldChanged(key, value, type){  
+
+        switch(type){
+            case 'file':
+                console.log(value);
+                if(ProgressBar.config.answeredFields[key] != undefined){
+                    ProgressBar.config.answeredFields[key] += value;
+                }else{
+                    ProgressBar.config.answeredFields[key] = 1;
+                }
+              
+                console.log('filevalue: '+ProgressBar.config.answeredFields[key]);
+                break;
+            case 'checkbox':
+                if(ProgressBar.config.answeredFields[key]){
+                    if(value == false){
+                        ProgressBar.config.answeredFields[key]--;
+                    }else{
+                        ProgressBar.config.answeredFields[key]++;
+                    }
+                }else{
+                    if(value == true){
+                        ProgressBar.config.answeredFields[key] = 1;
+                    }
+                }
+                break;
+            case 'select':
+                if(value != ''){
+                    ProgressBar.config.answeredFields[key] = 1;
+                }else{
+                    ProgressBar.config.answeredFields[key] = 0;
+                }
+                break;
+            default:
+                if(value){
+                    ProgressBar.config.answeredFields[key] = 1;
+                }else{
+                    ProgressBar.config.answeredFields[key] = 0;
+                }
+                break;
+        }
+
+        //recalculate total fields answered
+        var computeTotalAnsweredFields  = 0;
+        for(answeredField in ProgressBar.config.answeredFields){
+            if(ProgressBar.config.answeredFields[answeredField]){
+                computeTotalAnsweredFields ++;
+            }
+        }
+
+        //if the total changes, call updateWidth function setting a direction
+        if(computeTotalAnsweredFields > ProgressBar.config.totalAnsweredFields){
+            // console.log('Up answeredFields: ' + ProgressBar.config.answeredFields[key]);
+            ProgressBar.config.totalAnsweredFields = computeTotalAnsweredFields;
+            this.updateWidth('up');
+        }else if(computeTotalAnsweredFields < ProgressBar.config.totalAnsweredFields){
+            // console.log('Down answeredFields: ' + ProgressBar.config.answeredFields[key]);
+            ProgressBar.config.totalAnsweredFields = computeTotalAnsweredFields;
+            this.updateWidth('down');
+        }else{
+            this.updateWidth('keep');
+        }
+    },
+}
+
+window.ProgressBar = ProgressBar;

--- a/resources/js/progress-bar.js
+++ b/resources/js/progress-bar.js
@@ -49,14 +49,11 @@ var ProgressBar = {
 
         switch(type){
             case 'file':
-                console.log(value);
                 if(ProgressBar.config.answeredFields[key] != undefined){
                     ProgressBar.config.answeredFields[key] += value;
                 }else{
                     ProgressBar.config.answeredFields[key] = 1;
                 }
-              
-                console.log('filevalue: '+ProgressBar.config.answeredFields[key]);
                 break;
             case 'checkbox':
                 if(ProgressBar.config.answeredFields[key]){
@@ -97,11 +94,9 @@ var ProgressBar = {
 
         //if the total changes, call updateWidth function setting a direction
         if(computeTotalAnsweredFields > ProgressBar.config.totalAnsweredFields){
-            // console.log('Up answeredFields: ' + ProgressBar.config.answeredFields[key]);
             ProgressBar.config.totalAnsweredFields = computeTotalAnsweredFields;
             this.updateWidth('up');
         }else if(computeTotalAnsweredFields < ProgressBar.config.totalAnsweredFields){
-            // console.log('Down answeredFields: ' + ProgressBar.config.answeredFields[key]);
             ProgressBar.config.totalAnsweredFields = computeTotalAnsweredFields;
             this.updateWidth('down');
         }else{

--- a/resources/views/livewire/crud/change.blade.php
+++ b/resources/views/livewire/crud/change.blade.php
@@ -1,6 +1,10 @@
 <div>
     @include('livewire.crud.success')
 
+    <div id="myProgress mb-10">
+        <div id="myBar"></div>
+    </div>
+
     @if (!$finished)
         @error('generic_error')
             <div class="alert alert-error">
@@ -24,7 +28,7 @@
                     <label class="cursor-pointer label flex">
                         <span class="label-text bold">{{ $field['label'] }} <br /><span class="text-gray-400">{{ @$field['placeholder'] }}</span></span> 
                         <div>
-                            <input wire:model="{{ $key }}" type="checkbox" class="toggle toggle-primary"> 
+                            <input wire:model="{{ $key }}" type="checkbox"  onChange="ProgressBar.fieldChanged('{{ $key }}', this.value, '{{ $field['type'] }}')" class="toggle toggle-primary"> 
                             <span class="toggle-mark"></span>
                         </div>
                     </label>
@@ -35,7 +39,7 @@
                         <span class="label-text"><strong>{{ $field['label'] }}</strong></span> 
                         <a href="#" class="label-text-alt"></a>
                     </label> 
-                    <select wire:model="{{ $key }}" class="select select-bordered w-full @error($key) select-error @enderror">
+                    <select wire:model="{{ $key }}" onChange="ProgressBar.fieldChanged('{{ $key }}', this.value, '{{ $field['type'] }}')" class="select select-bordered w-full @error($key) select-error @enderror">
                         <option value=""> -- selecione --</option> 
                         @foreach ($field['options'] as $info)
                             <option value="{{ $info['id']}}">{{ $info['text']}}</option> 
@@ -48,7 +52,7 @@
                         @foreach ($field['options'] as $info)
                             <label class="cursor-pointer mr-5">
                                 <div class="inline-block">
-                                    <input wire:model="{{ $key }}" type="radio" checked="checked" class="radio radio-primary" value="{{ $info['id']}}"> 
+                                    <input wire:model="{{ $key }}" type="radio" checked="checked"  onChange="ProgressBar.fieldChanged('{{ $key }}', this.value, '{{ $field['type'] }}')" class="radio radio-primary" value="{{ $info['id']}}"> 
                                     <span class="radio-mark mr-1"></span>
                                 </div>
                                 <span class="label-text {{ @$field['style'] }}">{{ $info['text']}}</span> 
@@ -63,7 +67,7 @@
                         @foreach ($field['options'] as $checkbox_index => $info)
                             <label class="cursor-pointer mr-5">
                                 <div class="inline-block">
-                                    <input wire:model="{{ $key }}#{{ $checkbox_index }}" type="checkbox" checked="checked" class="checkbox checkbox-primary" value="{{ $info['id']}}"> 
+                                    <input wire:model="{{ $key }}#{{ $checkbox_index }}"  onChange="ProgressBar.fieldChanged('{{ $key }}', this.checked, '{{ $field['type'] }}')" type="checkbox" checked="checked" class="checkbox checkbox-primary" value="{{ $info['id']}}"> 
                                     <span class="radio-mark mr-1"></span>
                                 </div>
                                 <span class="label-text {{ @$field['style'] }}">{{ $info['text']}}</span> 
@@ -75,7 +79,7 @@
                     <label for="{{ $key }}" class="label">
                         <span class="label-text"><strong>{{ $field['label'] }}</strong></span>
                     </label>
-                    <input wire:model="{{ $key }}" type="date" name="{{ $key }}" placeholder="{{ @$field['placeholder'] }}" class="input input-bordered @error($key) input-error @enderror max-w-md" />
+                    <input wire:model="{{ $key }}" type="date" name="{{ $key }}"  onChange="ProgressBar.fieldChanged('{{ $key }}', this.value, '{{ $field['type'] }}')" placeholder="{{ @$field['placeholder'] }}" class="input input-bordered @error($key) input-error @enderror max-w-md" />
                     @break
                 @case('file')
                     <label class="label">
@@ -93,13 +97,16 @@
                                 labelFileProcessingComplete: 'Upload finalizado',
                                 server: {
                                     process: (fieldName, file, metadata, load, error, progress, abort, transfer, options) => {
-                                        @this.upload('{{ $key }}', file, load, error, progress)
+                                        @this.upload('{{ $key }}', file, load, error, progress);
+                                        ProgressBar.fieldChanged('{{ $key }}', 1, '{{ $field['type'] }}');
                                     },
                                     revert: (filename, load) => {
-                                        @this.removeUpload('{{ $key }}', filename, load)
+                                        @this.removeUpload('{{ $key }}', filename, load);
+                                        ProgressBar.fieldChanged('{{ $key }}',  -1, '{{ $field['type'] }}');
                                     },
                                 },
                             });
+                           
                     ">
                         <input type="file" name="{{ $key }}" x-ref="input">
                     </div>
@@ -132,13 +139,13 @@
                     <label for="{{ $key }}" class="label">
                         <span class="label-text"><strong>{{ $field['label'] }}</strong></span>
                     </label>
-                    <textarea wire:model="{{ $key }}" name="{{ $key }}" placeholder="{{ @$field['placeholder'] }}" class="textarea textarea-bordered h-48 mb-2 @error($key) textarea-error @enderror"></textarea>
+                    <textarea wire:model="{{ $key }}" name="{{ $key }}" onChange="ProgressBar.fieldChanged('{{ $key }}', this.value, '{{ $field['type'] }}')" placeholder="{{ @$field['placeholder'] }}" class="textarea textarea-bordered h-48 mb-2 @error($key) textarea-error @enderror"></textarea>
                     @break
                 @default
                     <label for="{{ $key }}" class="label">
                         <span class="label-text"><strong>{{ $field['label'] }}</strong></span>
                     </label>
-                    <input wire:model="{{ $key }}" type="text" name="{{ $key }}" placeholder="{{ @$field['placeholder'] }}" class="input input-bordered @error($key) input-error @enderror w-full" />
+                    <input wire:model="{{ $key }}" onChange="ProgressBar.fieldChanged('{{ $key }}', this.value, '{{ $field['type'] }}')" type="text" name="{{ $key }}" placeholder="{{ @$field['placeholder'] }}" class="input input-bordered @error($key) input-error @enderror w-full" />
                     @break
                 @endswitch
 
@@ -162,3 +169,21 @@
         @endif
     @endif
 </div> 
+
+
+@section('scripts')
+
+<script>
+    $(function () {
+        ProgressBar.init({
+            countFields : {{count($fields)}},
+            answeredFields : [],
+            totalAnsweredFields : 0,
+
+            containerId : 'myBar',
+            containerWidth : 1,
+        });
+    });
+</script>
+
+@endsection


### PR DESCRIPTION
Pra ter uma noção do funcionamento:

[Screencast from 25-07-2022 16:29:39.webm](https://user-images.githubusercontent.com/74692811/180860302-04afc60c-54dd-459a-9402-762402f106ee.webm)

Foi criado uma classe js contendo as chamadas de funções para serem utilizadas quando um elemento do questionário sofrer alguma alteração. 

Assim, quando acionada, faz a atualização da porcentagem de tamanho daquele elemento tendo como condição de parada o cálculo da porcentagem atualizada das perguntas respondidas.

A ideia seria deixar essa barra aparecendo quando o usuário rolar a tela para baixo, mas vou detalhar esses ajustes visuais numa issue separada. 