### PR TITLE
fix: #34, resetando barra de prograsso após submissão

### DIFF
--- a/resources/js/progress-bar.js
+++ b/resources/js/progress-bar.js
@@ -1,3 +1,7 @@
+const {
+    isSet, defaultsDeep, split
+} = require("lodash");
+
 var ProgressBar = {
     config: {
         countFields : 0,
@@ -87,25 +91,39 @@ var ProgressBar = {
                 break;
         }
 
-        //recalculate total fields answered
-        var computeTotalAnsweredFields  = 0;
-        for(answeredField in ProgressBar.config.answeredFields){
-            if(ProgressBar.config.answeredFields[answeredField]){
-                computeTotalAnsweredFields ++;
-            }
-        }
-
-        //if the total changes, call updateWidth function setting a direction
-        if(computeTotalAnsweredFields > ProgressBar.config.totalAnsweredFields){
-            ProgressBar.config.totalAnsweredFields = computeTotalAnsweredFields;
-            this.updateWidth('up');
-        }else if(computeTotalAnsweredFields < ProgressBar.config.totalAnsweredFields){
-            ProgressBar.config.totalAnsweredFields = computeTotalAnsweredFields;
-            this.updateWidth('down');
-        }else{
-            this.updateWidth('keep');
-        }
+        this.refreshProgressBar();
+       
     },
+
+    refreshProgressBar(){
+         //recalculate total fields answered
+         var computeTotalAnsweredFields  = 0;
+         for(answeredField in ProgressBar.config.answeredFields){
+             if(ProgressBar.config.answeredFields[answeredField]){
+                 computeTotalAnsweredFields ++;
+             }
+         }
+ 
+         //if the total changes, call updateWidth function setting a direction
+         if(computeTotalAnsweredFields > ProgressBar.config.totalAnsweredFields){
+             ProgressBar.config.totalAnsweredFields = computeTotalAnsweredFields;
+             this.updateWidth('up');
+         }else if(computeTotalAnsweredFields < ProgressBar.config.totalAnsweredFields){
+             ProgressBar.config.totalAnsweredFields = computeTotalAnsweredFields;
+             this.updateWidth('down');
+         }else{
+             this.updateWidth('keep');
+         }
+    },
+
+    reset(){
+        ProgressBar.config.answeredFields = [];
+        ProgressBar.config.totalAnsweredFields = 0,
+        ProgressBar.config.containerWidth = 1;
+
+        this.refreshProgressBar();
+
+    }
 }
 
 window.ProgressBar = ProgressBar;

--- a/resources/views/livewire/crud/success.blade.php
+++ b/resources/views/livewire/crud/success.blade.php
@@ -7,6 +7,6 @@
     </div>
 
     <div class="flex-none">
-        <button class="btn btn-sm btn-success pt-0" wire:click="finished(false, {{$form->id}})">Ok</button>
+        <button class="btn btn-sm btn-success pt-0" wire:click="finished(false, {{$form->id}})" onclick="ProgressBar.reset()">Ok</button>
     </div>
 </div>


### PR DESCRIPTION
No botão 'ok' da mensagem de sucesso, onde é feita a chamada para a função store() do livewire, é feito também uma chamada da função reset() da barra de progresso.

[Screencast from 11-08-2022 15:22:48.webm](https://user-images.githubusercontent.com/74692811/184211793-105b0c53-e9f7-42ab-bb5c-e3524a0b43ee.webm)
